### PR TITLE
Add .env file

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+GENERATE_SOURCEMAP=false


### PR DESCRIPTION
The GENERATE_SOURCEMAP directive supresses a spurious build error.