### PR TITLE
Add static layout options from Cytoscape

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "cytoscape": "^3.23.0",
         "d3-force": "^3.0.0",
         "geojs": "^1.10.10",
         "react": "^18.2.0",
@@ -22,6 +23,7 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "@types/cytoscape": "^3.19.9",
         "@types/d3-force": "^3.0.3",
         "@types/jest": "^29.0.3",
         "@types/node": "^18.7.23",
@@ -4412,6 +4414,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cytoscape": {
+      "version": "3.19.9",
+      "resolved": "https://registry.npmjs.org/@types/cytoscape/-/cytoscape-3.19.9.tgz",
+      "integrity": "sha512-oqCx0ZGiBO0UESbjgq052vjDAy2X53lZpMrWqiweMpvVwKw/2IiYDdzPFK6+f4tMfdv9YKEM9raO5bAZc3UYBg==",
+      "dev": true
+    },
     "node_modules/@types/d3-force": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.3.tgz",
@@ -7231,6 +7239,18 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
+    "node_modules/cytoscape": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.23.0.tgz",
+      "integrity": "sha512-gRZqJj/1kiAVPkrVFvz/GccxsXhF3Qwpptl32gKKypO4IlqnKBjTOu+HbXtEggSGzC5KCaHp3/F7GgENrtsFkA==",
+      "dependencies": {
+        "heap": "^0.2.6",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/d3": {
       "version": "3.5.17",
       "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
@@ -9847,6 +9867,11 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/heap": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.7.tgz",
+      "integrity": "sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg=="
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
@@ -22155,6 +22180,12 @@
         "@types/node": "*"
       }
     },
+    "@types/cytoscape": {
+      "version": "3.19.9",
+      "resolved": "https://registry.npmjs.org/@types/cytoscape/-/cytoscape-3.19.9.tgz",
+      "integrity": "sha512-oqCx0ZGiBO0UESbjgq052vjDAy2X53lZpMrWqiweMpvVwKw/2IiYDdzPFK6+f4tMfdv9YKEM9raO5bAZc3UYBg==",
+      "dev": true
+    },
     "@types/d3-force": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.3.tgz",
@@ -24325,6 +24356,15 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
+    "cytoscape": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.23.0.tgz",
+      "integrity": "sha512-gRZqJj/1kiAVPkrVFvz/GccxsXhF3Qwpptl32gKKypO4IlqnKBjTOu+HbXtEggSGzC5KCaHp3/F7GgENrtsFkA==",
+      "requires": {
+        "heap": "^0.2.6",
+        "lodash": "^4.17.21"
+      }
+    },
     "d3": {
       "version": "3.5.17",
       "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
@@ -26288,6 +26328,11 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
+    },
+    "heap": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.7.tgz",
+      "integrity": "sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg=="
     },
     "hoist-non-react-statics": {
       "version": "3.3.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "cytoscape": "^3.23.0",
     "d3-force": "^3.0.0",
     "geojs": "^1.10.10",
     "react": "^18.2.0",
@@ -17,6 +18,7 @@
     "web-vitals": "^2.1.4"
   },
   "devDependencies": {
+    "@types/cytoscape": "^3.19.9",
     "@types/d3-force": "^3.0.3",
     "@types/jest": "^29.0.3",
     "@types/node": "^18.7.23",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,7 +91,7 @@ function App() {
           <ToolbarMenu
             header="Layout"
             description="Select a layout"
-            options={["force", "circle", "kaluza-klein manifold"]}
+            options={["force", "circle", "grid", "null"]}
             setExternalState={setLayout}
           />
         </Toolbar>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import Toolbar from '@mui/material/Toolbar';
 import ToolbarMenu from './ToolbarMenu';
 import Typography from '@mui/material/Typography';
 import { GraphData, fetchNetworkData, getNetwork } from './util';
+import { layouts } from './layout';
 import './App.css';
 
 const emptyGraph = {
@@ -91,7 +92,7 @@ function App() {
           <ToolbarMenu
             header="Layout"
             description="Select a layout"
-            options={["force", "circle", "grid", "null"]}
+            options={["force", ...layouts]}
             setExternalState={setLayout}
           />
         </Toolbar>

--- a/src/Graph.tsx
+++ b/src/Graph.tsx
@@ -195,6 +195,8 @@ class Graph extends Component<GraphProps, never> {
       });
 
     this.copyData();
+
+    this.applyLayout();
   }
 
   componentDidUpdate(prevProps: GraphProps) {
@@ -211,10 +213,29 @@ class Graph extends Component<GraphProps, never> {
     }
 
     if (prevProps.layout !== this.props.layout) {
+      this.applyLayout();
+    }
+  }
+
+  styleLines() {
+    this.line.style({
+      strokeColor: this.props.edgeColor,
+    }).draw();
+  }
+
+  styleNodes() {
+    this.marker.style({
+      fillColor: (d: Node) => d.fixed ? "blue" : this.props.nodeColor,
+    }).draw();
+  }
+
+  applyLayout() {
       const layout = this.props.layout;
 
       if (isLayout(layout)) {
-        this.stopSimulation();
+        this.stopSimulation({
+          force: true,
+        });
         this.forcesActive = false;
 
         const positions = cytoscapeLayout(this.nodes, this.edges, layout);
@@ -231,19 +252,6 @@ class Graph extends Component<GraphProps, never> {
       this.line.data(this.edges).draw();
 
       this.updateTooltipPositions();
-    }
-  }
-
-  styleLines() {
-    this.line.style({
-      strokeColor: this.props.edgeColor,
-    }).draw();
-  }
-
-  styleNodes() {
-    this.marker.style({
-      fillColor: (d: Node) => d.fixed ? "blue" : this.props.nodeColor,
-    }).draw();
   }
 
   copyData() {
@@ -290,8 +298,8 @@ class Graph extends Component<GraphProps, never> {
     }
   }
 
-  stopSimulation() {
-    if (this.forcesActive) {
+  stopSimulation({ force = false }: { force: boolean }) {
+    if (this.forcesActive || force) {
       this.sim.stop();
     }
   }

--- a/src/Graph.tsx
+++ b/src/Graph.tsx
@@ -5,6 +5,7 @@ import { GraphData, Node, Edge } from './util';
 import { cytoscapeLayout, isLayout } from './layout';
 
 import type { NodeDatum } from './util';
+import type { NodePosition } from './layout';
 import type { SimulationNodeDatum } from 'd3-force';
 
 interface GraphProps {
@@ -239,10 +240,7 @@ class Graph extends Component<GraphProps, never> {
         this.forcesActive = false;
 
         const positions = cytoscapeLayout(this.nodes, this.edges, layout);
-        for (const key in positions) {
-          this.nodes[key].x = positions[key].x;
-          this.nodes[key].y = positions[key].y;
-        }
+        this.updateNodePositions(positions);
       } else {
         this.forcesActive = true;
         this.startSimulation();
@@ -261,6 +259,13 @@ class Graph extends Component<GraphProps, never> {
     this.sim.nodes(this.nodes)
         .force("link", forceLink(this.edges).distance(10))
     this.startSimulation();
+  }
+
+  updateNodePositions(positions: readonly NodePosition[]) {
+    for (const p of positions) {
+      this.nodes[p.id].x = p.x;
+      this.nodes[p.id].y = p.y;
+    }
   }
 
   zoomToFit() {

--- a/src/Graph.tsx
+++ b/src/Graph.tsx
@@ -2,6 +2,7 @@ import { Component, createRef, RefObject } from 'react';
 import geo from 'geojs';
 import { forceSimulation, forceCenter, forceManyBody, forceCollide, forceLink, Simulation } from 'd3-force';
 import { GraphData, Node, Edge } from './util';
+import { cytoscapeLayout, isLayout } from './layout';
 
 import type { NodeDatum } from './util';
 import type { SimulationNodeDatum } from 'd3-force';
@@ -216,6 +217,24 @@ class Graph extends Component<GraphProps, never> {
 
     if (prevProps.data !== this.props.data) {
       this.copyData();
+    }
+
+    if (prevProps.layout !== this.props.layout) {
+      const layout = this.props.layout;
+
+      if (isLayout(layout)) {
+        this.sim.stop();
+
+        const positions = cytoscapeLayout(this.nodes, layout);
+        console.log(positions);
+        for (const key in positions) {
+          this.nodes[key].x = positions[key].x;
+          this.nodes[key].y = positions[key].y;
+        }
+       }
+
+       this.marker.data(this.nodes).draw();
+       this.line.data(this.edges).draw();
     }
   }
 

--- a/src/Graph.tsx
+++ b/src/Graph.tsx
@@ -217,7 +217,7 @@ class Graph extends Component<GraphProps, never> {
         this.stopSimulation();
         this.forcesActive = false;
 
-        const positions = cytoscapeLayout(this.nodes, layout);
+        const positions = cytoscapeLayout(this.nodes, this.edges, layout);
         for (const key in positions) {
           this.nodes[key].x = positions[key].x;
           this.nodes[key].y = positions[key].y;

--- a/src/Graph.tsx
+++ b/src/Graph.tsx
@@ -192,15 +192,7 @@ class Graph extends Component<GraphProps, never> {
         this.marker.data(this.nodes).draw();
         this.line.data(this.edges).draw();
 
-        this.marker.data().forEach((d: Node) => {
-          if (this.tooltips.hasOwnProperty(d.id)) {
-            const tt = this.tooltips[d.id];
-            tt.position({
-              x: d.x,
-              y: d.y,
-            });
-          }
-        });
+        this.updateTooltipPositions();
       });
 
     this.copyData();
@@ -235,15 +227,7 @@ class Graph extends Component<GraphProps, never> {
        this.marker.data(this.nodes).draw();
        this.line.data(this.edges).draw();
 
-       this.marker.data().forEach((d: Node) => {
-         if (this.tooltips.hasOwnProperty(d.id)) {
-           const tt = this.tooltips[d.id];
-           tt.position({
-             x: d.x,
-             y: d.y,
-           });
-         }
-       });
+       this.updateTooltipPositions();
     }
   }
 
@@ -283,6 +267,18 @@ class Graph extends Component<GraphProps, never> {
 
   async screencap() {
     return await this.map.screenshot();
+  }
+
+  updateTooltipPositions() {
+    this.marker.data().forEach((d: Node) => {
+      if (this.tooltips.hasOwnProperty(d.id)) {
+        const tt = this.tooltips[d.id];
+        tt.position({
+          x: d.x,
+          y: d.y,
+        });
+      }
+    });
   }
 
   render() {

--- a/src/Graph.tsx
+++ b/src/Graph.tsx
@@ -150,7 +150,7 @@ class Graph extends Component<GraphProps, never> {
       node.fx = startPos.x + evt.mouse.geo.x - evt.state.origin.geo.x;
       node.fy = startPos.y + evt.mouse.geo.y - evt.state.origin.geo.y;
 
-      if (this.tooltips.hasOwnProperty(node.id)) {
+      if (this.forcesActive && this.tooltips.hasOwnProperty(node.id)) {
         const tt = this.tooltips[node.id];
         tt.position({
           x: node.fx,

--- a/src/Graph.tsx
+++ b/src/Graph.tsx
@@ -127,7 +127,6 @@ class Graph extends Component<GraphProps, never> {
     let node: Node | null = null;
     let startPos = { x: 0, y: 0 };
     this.marker.geoOn(geo.event.feature.mouseon, (evt: GeojsEvent<Node>) => {
-      console.log(evt);
       node = evt.data;
       if (!node) {
         throw new Error("mouseon failed");
@@ -228,10 +227,10 @@ class Graph extends Component<GraphProps, never> {
         this.startSimulation();
       }
 
-       this.marker.data(this.nodes).draw();
-       this.line.data(this.edges).draw();
+      this.marker.data(this.nodes).draw();
+      this.line.data(this.edges).draw();
 
-       this.updateTooltipPositions();
+      this.updateTooltipPositions();
     }
   }
 

--- a/src/layout.tsx
+++ b/src/layout.tsx
@@ -1,8 +1,9 @@
 import cy from "cytoscape";
 
 import type { Node } from './util';
+import type { LayoutOptions } from 'cytoscape';
 
-const layouts = ["null", "grid", "circle"] as const;
+export const layouts = ["random", "grid", "circle", "concentric", "breadthfirst", "cose"] as const;
 type Layout = typeof layouts[number];
 
 interface Position {
@@ -24,7 +25,7 @@ export function isLayout(s: string): s is Layout {
   return (layouts as readonly string[]).includes(s);
 }
 
-export function cytoscapeLayout(nodes: Node[], layout: "null" | "grid" | "circle") {
+export function cytoscapeLayout(nodes: Node[], layout: Layout) {
   // Run a cytoscape layout.
   const c = cy({
     elements: nodes.map((n) => ({

--- a/src/layout.tsx
+++ b/src/layout.tsx
@@ -6,6 +6,12 @@ import type { LayoutOptions } from 'cytoscape';
 export const layouts = ["random", "grid", "circle", "concentric", "breadthfirst", "cose"] as const;
 type Layout = typeof layouts[number];
 
+export interface NodePosition {
+  id: number;
+  x: number;
+  y: number;
+}
+
 interface Position {
   x: number;
   y: number;
@@ -25,7 +31,7 @@ export function isLayout(s: string): s is Layout {
   return (layouts as readonly string[]).includes(s);
 }
 
-export function cytoscapeLayout(nodes: Node[], edges: Edge[], layout: Layout) {
+export function cytoscapeLayout(nodes: Node[], edges: Edge[], layout: Layout): NodePosition[] {
   // Run a cytoscape layout.
   const c = cy({
     elements: {
@@ -126,12 +132,9 @@ export function cytoscapeLayout(nodes: Node[], edges: Edge[], layout: Layout) {
   const cy_mean = pos_mean(cy_pos);
 
   // Transcribe the laid-out positions, maintaining the original mean position.
-  let map: {[n: number]: {x: number, y: number}} = {};
-  for (const p of cy_pos) {
-    map[+p.id] = {
-      x: p.x - cy_mean.x + node_mean.x,
-      y: p.y - cy_mean.y + node_mean.y,
-    };
-  }
-  return map;
+  return cy_pos.map((p) => ({
+    id: +p.id,
+    x: p.x - cy_mean.x + node_mean.x,
+    y: p.y - cy_mean.y + node_mean.y,
+  }));
 }

--- a/src/layout.tsx
+++ b/src/layout.tsx
@@ -5,11 +5,27 @@ import type { Node } from './util';
 const layouts = ["null", "grid", "circle"] as const;
 type Layout = typeof layouts[number];
 
+interface Position {
+  x: number;
+  y: number;
+}
+
+function pos_mean(data: Position[]): Position {
+  const adder = (acc: number, x: number): number => acc + x;
+  const length = data.length;
+
+  return {
+    x: data.map((d) => d.x).reduce(adder, 0) / length,
+    y: data.map((d) => d.y).reduce(adder, 0) / length,
+  };
+}
+
 export function isLayout(s: string): s is Layout {
   return (layouts as readonly string[]).includes(s);
 }
 
 export function cytoscapeLayout(nodes: Node[], layout: "null" | "grid" | "circle") {
+  // Run a cytoscape layout.
   const c = cy({
     elements: nodes.map((n) => ({
       group: "nodes",
@@ -24,10 +40,32 @@ export function cytoscapeLayout(nodes: Node[], layout: "null" | "grid" | "circle
   });
   l.run();
 
-  let map: {[n: number]: {x: number, y: number}} = {};
-  for (let i=0; i<c.nodes().length; i += 1) {
+  // Pull the laid-out positions out into an array. (Even though the cytoscape
+  // docs claim that the nodes collection can be subjected to iteration, etc.,
+  // the published types don't actually allow it, so we have to jump through
+  // this hoop).
+  let cy_pos: { id: string, x: number, y: number }[] = [];
+  for (let i=0; i < c.nodes().length; i += 1) {
     const n = c.nodes()[i];
-    map[+n.data("id")] = n.position();
+    const p = n.position();
+    cy_pos[i] = {
+      id: n.id(),
+      x: p.x,
+      y: p.y,
+    }
+  }
+
+  // Calculate the mean of the node positions, pre- and post-layout.
+  const node_mean = pos_mean(nodes);
+  const cy_mean = pos_mean(cy_pos);
+
+  // Transcribe the laid-out positions, maintaining the original mean position.
+  let map: {[n: number]: {x: number, y: number}} = {};
+  for (const p of cy_pos) {
+    map[+p.id] = {
+      x: p.x - cy_mean.x + node_mean.x,
+      y: p.y - cy_mean.y + node_mean.y,
+    };
   }
   return map;
 }

--- a/src/layout.tsx
+++ b/src/layout.tsx
@@ -73,9 +73,7 @@ export function cytoscapeLayout(nodes: Node[], edges: Edge[], layout: Layout) {
       opts = {
         name: "concentric",
         concentric: (node) => {
-          const level = Math.floor(Math.random() * 3);
-          console.log(level);
-          return level;
+          return Math.floor(Math.random() * 3);
         },
         levelWidth: (nodes) => 1,
       };

--- a/src/layout.tsx
+++ b/src/layout.tsx
@@ -1,0 +1,33 @@
+import cy from "cytoscape";
+
+import type { Node } from './util';
+
+const layouts = ["null", "grid", "circle"] as const;
+type Layout = typeof layouts[number];
+
+export function isLayout(s: string): s is Layout {
+  return (layouts as readonly string[]).includes(s);
+}
+
+export function cytoscapeLayout(nodes: Node[], layout: "null" | "grid" | "circle") {
+  const c = cy({
+    elements: nodes.map((n) => ({
+      group: "nodes",
+      data: {
+        id: `${n.id}`,
+      },
+    })),
+  });
+
+  const l = c.layout({
+    name: layout,
+  });
+  l.run();
+
+  let map: {[n: number]: {x: number, y: number}} = {};
+  for (let i=0; i<c.nodes().length; i += 1) {
+    const n = c.nodes()[i];
+    map[+n.data("id")] = n.position();
+  }
+  return map;
+}


### PR DESCRIPTION
This PR adds several Cytoscape layout options to the demo app.

This works by setting up a Cytoscape instance to run its layout algorithms on the current positions of the graph, then applying those positions to the graph. This enables other use cases as well, such as other layout engines, or manually provides layouts for the graph.

Closes #14